### PR TITLE
Feat/bs update errors

### DIFF
--- a/configs/virtual.js
+++ b/configs/virtual.js
@@ -23,7 +23,11 @@ store.put = (k, v) => { s[k] = v; return Promise.resolve(null) }
 store.del = (k) => { s[k] = undefined; return Promise.resolve(null) }
 
 const crypto = require('crypto')
-const token = crypto.randomBytes(32).toString('hex')
+const base64url = require('base64url')
+const token = base64url(JSON.stringify({
+  channel: crypto.randomBytes(32).toString('hex'),
+  host: 'ws://broker.hivemq.com:8000'
+}))
 
 // These objects specify the configs of different
 // plugins. There must be 2, so that they can send

--- a/configs/virtual.js
+++ b/configs/virtual.js
@@ -24,9 +24,11 @@ store.del = (k) => { s[k] = undefined; return Promise.resolve(null) }
 
 const crypto = require('crypto')
 const base64url = require('base64url')
+
+// give a well formed token as a placeholder, but connection is mocked
 const token = base64url(JSON.stringify({
   channel: crypto.randomBytes(32).toString('hex'),
-  host: 'ws://broker.hivemq.com:8000'
+  host: 'ws://broker.mqtt.example:8000'
 }))
 
 // These objects specify the configs of different

--- a/test/connectSpec.js
+++ b/test/connectSpec.js
@@ -43,7 +43,7 @@ describe('Plugin setup', function () {
       })
       this.plugin.connect()
         .then((result) => {
-          assert.isNull(result, 'connect should return a promise to null')
+          assert.isNotOk(result, 'connect should return a promise to null')
         })
         .catch(done)
     })
@@ -59,7 +59,7 @@ describe('Plugin setup', function () {
     it('should resolve to null', function (done) {
       this.plugin.connect()
         .then((result) => {
-          assert.isNull(result)
+          assert.isNotOk(result)
           done()
         })
     })
@@ -88,7 +88,7 @@ describe('Plugin setup', function () {
       this.plugin.once('connect', () => {
         this.plugin.disconnect()
           .then((result) => {
-            assert.isNull(result, 'disconnect should return a promise to null')
+            assert.isNotOk(result, 'disconnect should return a promise to null')
           })
           .catch(done)
       })
@@ -100,7 +100,7 @@ describe('Plugin setup', function () {
       this.plugin.once('connect', () => {
         this.plugin.disconnect()
           .then((result) => {
-            assert.isNull(result)
+            assert.isNotOk(result)
             done()
           })
       })


### PR DESCRIPTION
Resolves https://github.com/interledger/js-ilp-plugin-tests/issues/5 . Use the error types specified in ILP RFC 004 as much as possible. Error types are up to date with https://github.com/interledger/rfcs/pull/98 .`configs/virtual.js` depends on https://github.com/interledger/js-ilp-plugin-virtual/pull/17 . Once that PR is merged and so it this one, `configs/virtual.js` will be moved into `ilp-plugin-virtual`.